### PR TITLE
Implement the Hash64 interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ A Go port of the [SeaHash](https://ticki.github.io/blog/seahash-explained/) algo
 
 ## Benchmarks
 
-On Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz, with go 1.9.1.
+Intel(R) Xeon(R) CPU E3-1505M v6 @ 3.00GHz
 
 ```
-$ go test -bench . -benchmem
-BenchmarkSum-4     	20000000	        63.5 ns/op
-BenchmarkSum64-4   	30000000	        43.1 ns/op
+$ go test -bench .
+BenchmarkSum-8     	30000000	        47.2 ns/op
+BenchmarkSum64-8   	50000000	        33.0 ns/op
 ```

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@
 A Go port of the [SeaHash](https://ticki.github.io/blog/seahash-explained/) algorithm.
 
 ## Benchmarks
+
+On Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz, with go 1.9.1.
+
 ```
 $ go test -bench . -benchmem
-BenchmarkHash-4      	30000000	        41.0 ns/op	       0 B/op	       0 allocs/op
-BenchmarkDiffuse-4   	2000000000	         0.29 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSum-4     	20000000	        63.5 ns/op
+BenchmarkSum64-4   	30000000	        43.1 ns/op
 ```

--- a/seahash.go
+++ b/seahash.go
@@ -5,7 +5,6 @@
 package seahash
 
 import (
-	"bytes"
 	"encoding/binary"
 	"hash"
 )
@@ -25,8 +24,14 @@ const (
 )
 
 type digest struct {
-	state  state
-	buffer bytes.Buffer
+	state state
+	// Cumulative # of bytes written.
+	inputSize int
+
+	// buf[:bufSize] keeps a subword-sized input that was left over from the
+	// previous call to Write.
+	bufSize int
+	buf     [chunkSize]byte
 }
 
 // New creates a new SeaHash hash.Hash64
@@ -41,7 +46,8 @@ func (d *digest) Reset() {
 	d.state.b = seed2
 	d.state.c = seed3
 	d.state.d = seed4
-	d.buffer.Reset()
+	d.inputSize = 0
+	d.bufSize = 0
 }
 
 // Size returns Size constant to satisfy hash.Hash interface
@@ -51,7 +57,28 @@ func (d *digest) Size() int { return Size }
 func (d *digest) BlockSize() int { return BlockSize }
 
 func (d *digest) Write(b []byte) (nn int, err error) {
-	return d.buffer.Write(b)
+	nn = len(b)
+	d.inputSize += len(b)
+	if d.bufSize > 0 {
+		n := len(d.buf) - d.bufSize
+		copy(d.buf[d.bufSize:], b)
+		if n > len(b) {
+			d.bufSize += len(b)
+			return
+		}
+		d.state.update(readInt(d.buf[:]))
+		d.bufSize = 0
+		b = b[n:]
+	}
+	for len(b) >= chunkSize {
+		d.state.update(readInt(b[:chunkSize]))
+		b = b[chunkSize:]
+	}
+	if len(b) > 0 {
+		d.bufSize = len(b)
+		copy(d.buf[:], b)
+	}
+	return
 }
 
 func (d *digest) Sum(b []byte) []byte {
@@ -62,15 +89,12 @@ func (d *digest) Sum(b []byte) []byte {
 }
 
 func (d *digest) Sum64() uint64 {
-	bl := uint64(d.buffer.Len())
-	for {
-		if buf := d.buffer.Next(chunkSize); len(buf) > 0 {
-			d.state.update(readInt(buf))
-		} else {
-			break
-		}
+	if d.bufSize > 0 {
+		s := d.state
+		s.update(readInt(d.buf[:d.bufSize]))
+		return diffuse(s.a ^ s.b ^ s.c ^ s.d ^ uint64(d.inputSize))
 	}
-	return diffuse(d.state.a^d.state.b^d.state.c^d.state.d^bl)
+	return diffuse(d.state.a ^ d.state.b ^ d.state.c ^ d.state.d ^ uint64(d.inputSize))
 }
 
 // Sum is a convenience method that returns the checksum of the byte slice
@@ -78,6 +102,14 @@ func Sum(b []byte) []byte {
 	var d digest
 	d.Reset()
 	return d.Sum(b)
+}
+
+// Sum64 is a convenience method that returns uint64 checksum of the byte slice
+func Sum64(b []byte) uint64 {
+	var d digest
+	d.Reset()
+	d.Write(b)
+	return d.Sum64()
 }
 
 type state struct {

--- a/seahash_test.go
+++ b/seahash_test.go
@@ -14,12 +14,18 @@ func ExampleSum() {
 	// Output: 75e54a6f823a991b
 }
 
-func ExampleSum64() {
+func ExampleNew() {
 	// hash some bytes
 	h := New()
 	h.Write([]byte("to be or not to be"))
 	hash := h.Sum64()
 	fmt.Printf("%x", hash)
+	// Output: 1b993a826f4ae575
+}
+
+func ExampleSum64() {
+	// hash some bytes
+	fmt.Printf("%x", Sum64([]byte("to be or not to be")))
 	// Output: 1b993a826f4ae575
 }
 

--- a/seahash_test.go
+++ b/seahash_test.go
@@ -14,6 +14,15 @@ func ExampleSum() {
 	// Output: 75e54a6f823a991b
 }
 
+func ExampleSum64() {
+	// hash some bytes
+	h := seahash.New()
+	h.Write([]byte("to be or not to be"))
+	hash := h.Sum64()
+	fmt.Printf("%x", hash)
+	// Output: 1b993a826f4ae575
+}
+
 func TestHash(t *testing.T) {
 	h := seahash.New()
 	h.Write([]byte("to be or "))
@@ -26,8 +35,21 @@ func TestHash(t *testing.T) {
 }
 
 func BenchmarkSum(b *testing.B) {
+	h := seahash.New()
+	data := []byte("to be or not to be")
 	for i := 0; i < b.N; i++ {
-		seahash.Sum([]byte("to be or not to be"))
+		h.Sum(data)
+		h.Reset()
+	}
+}
+
+func BenchmarkSum64(b *testing.B) {
+	h := seahash.New()
+	data := []byte("to be or not to be")
+	for i := 0; i < b.N; i++ {
+		h.Write(data)
+		h.Sum64()
+		h.Reset()
 	}
 }
 

--- a/seahash_test.go
+++ b/seahash_test.go
@@ -1,41 +1,53 @@
-package seahash_test
+package seahash
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/blainsmith/seahash"
+	"math/rand"
 )
 
 func ExampleSum() {
 	// hash some bytes
-	hash := seahash.Sum([]byte("to be or not to be"))
+	hash := Sum([]byte("to be or not to be"))
 	fmt.Printf("%x", hash)
 	// Output: 75e54a6f823a991b
 }
 
 func ExampleSum64() {
 	// hash some bytes
-	h := seahash.New()
+	h := New()
 	h.Write([]byte("to be or not to be"))
 	hash := h.Sum64()
 	fmt.Printf("%x", hash)
 	// Output: 1b993a826f4ae575
 }
 
-func TestHash(t *testing.T) {
-	h := seahash.New()
-	h.Write([]byte("to be or "))
-	h.Write([]byte("not to be"))
-	s := fmt.Sprintf("%x", h.Sum(nil))
-
-	if s != "75e54a6f823a991b" {
-		t.Fail()
+func TestRandom(t *testing.T) {
+	expected := "d30e85ff891306b8"
+	str := []byte("abcdegfhijklmnabcdegfhijklmnabcdegfhijklmn")
+	for i := 0; i < 1000; i++ {
+		r := rand.NewSource(int64(i))
+		s := str
+		h := New()
+		// Split "str" into random fragments and add them to Write.  The
+		// final result should be the same.
+		for len(s) > 0 {
+			n := int(r.Int63()%int64(len(s))) + 1
+			h.Write(s[:n])
+			// Make a dummy call to Sum64() to detect when it causes
+			// an unwanted state change.
+			h.Sum64()
+			s = s[n:]
+		}
+		if s := fmt.Sprintf("%x", h.Sum(nil)); s != expected {
+			t.Errorf("seed %d: %v", i, s)
+		}
 	}
 }
 
 func BenchmarkSum(b *testing.B) {
-	h := seahash.New()
+	h := New()
 	data := []byte("to be or not to be")
 	for i := 0; i < b.N; i++ {
 		h.Sum(data)
@@ -44,17 +56,14 @@ func BenchmarkSum(b *testing.B) {
 }
 
 func BenchmarkSum64(b *testing.B) {
-	h := seahash.New()
 	data := []byte("to be or not to be")
 	for i := 0; i < b.N; i++ {
-		h.Write(data)
-		h.Sum64()
-		h.Reset()
+		Sum64(data)
 	}
 }
 
 func TestSizes(t *testing.T) {
-	h := seahash.New()
+	h := New()
 
 	if h.Size() != 8 {
 		t.Fail()


### PR DESCRIPTION
Also rewrite the internals to avoid memory allocations.

Before:
BenchmarkSum-4   	10000000	       126 ns/op

After:
BenchmarkSum-4     	20000000	        63.5 ns/op
BenchmarkSum64-4   	30000000	        43.1 ns/op